### PR TITLE
Migrate to provided.al2 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/function/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.21
 
       - name: Format Check
         run: cd function && if [ $(gofmt -l -s . | grep -E -v '^vendor/' | tee /tmp/gofmt.txt
@@ -34,13 +34,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.21
 
       - name: Build
-        run: cd function && go build -v ./...
+        run: cd function && go build -v -tags lambda.norpc ./...
 
       - name: Test
-        run: cd function && go test -v -covermode="count" -coverprofile="/tmp/coverage.out"
+        run: cd function && go test -v -tags lambda.norpc -covermode="count" -coverprofile="/tmp/coverage.out"
 
       - name: Coverage Report
         run: cd function && go tool cover -func="/tmp/coverage.out"

--- a/aws-serverless/deploy.sh
+++ b/aws-serverless/deploy.sh
@@ -14,12 +14,12 @@ if [ ! -f "${SANITY}" ] ; then
 fi
 
 cd "${FUNC_DIR_RELATIVE}"
-GOOS=linux GOARCH=amd64 go build -o main
+GOOS=linux GOARCH=amd64 go build -o bootstrap
 cd -
 
-mv "${FUNC_DIR_RELATIVE}/main" ./
+mv "${FUNC_DIR_RELATIVE}/bootstrap" ./
 sam deploy --tags "project=s3_new_file_email_lambda" $@
-rm -f ./main
+rm -f ./bootstrap
 
 
 

--- a/aws-serverless/deploy.sh
+++ b/aws-serverless/deploy.sh
@@ -14,7 +14,7 @@ if [ ! -f "${SANITY}" ] ; then
 fi
 
 cd "${FUNC_DIR_RELATIVE}"
-GOOS=linux GOARCH=amd64 go build -o bootstrap
+GOOS=linux GOARCH=arm64 go build -o bootstrap
 cd -
 
 mv "${FUNC_DIR_RELATIVE}/bootstrap" ./

--- a/aws-serverless/deploy.sh
+++ b/aws-serverless/deploy.sh
@@ -14,12 +14,14 @@ if [ ! -f "${SANITY}" ] ; then
 fi
 
 cd "${FUNC_DIR_RELATIVE}"
-GOOS=linux GOARCH=arm64 go build -o bootstrap
+GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o bootstrap
+zip bootstrap.zip bootstrap
+rm -f ./bootstrap
 cd -
 
-mv "${FUNC_DIR_RELATIVE}/bootstrap" ./
+mv "${FUNC_DIR_RELATIVE}/bootstrap.zip" ./
 sam deploy --tags "project=s3_new_file_email_lambda" $@
-rm -f ./bootstrap
+rm -f ./bootstrap.zip
 
 
 

--- a/aws-serverless/template.yml
+++ b/aws-serverless/template.yml
@@ -66,10 +66,14 @@ Resources:
       RetentionInDays: '14'
   Function:
     Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: go1.x
     Properties:
       FunctionName: !Join ['-', [!Ref AWS::StackName, lambda]]
-      Handler: main
-      Runtime: go1.x
+      Handler: bootstrap
+      Runtime: provided.al2
+      Architectures:
+        - arm64
       CodeUri: .
       Description: Send an email when files appear in S3
       Timeout: 60


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/